### PR TITLE
Fix for empty arrays in options[0].label

### DIFF
--- a/src/components/FieldConnect.jsx
+++ b/src/components/FieldConnect.jsx
@@ -21,7 +21,7 @@ export const FieldConnect = (Component) => {
                 return;
             }
 
-            if (name && value) {
+            if (value) {
                 setModel(name, value);
             } else if (Array.isArray(options) && options.length) {
                 setModel(name, options[0].label ? options[0].value : options[0]);
@@ -29,11 +29,8 @@ export const FieldConnect = (Component) => {
         }
 
         componentWillMount() {
-            const { name, value, options, onChangeModel } = this.props;
-            const { setModel, eventsListener } = this.context;
-            if (typeof setModel !== 'function') {
-                return;
-            }
+            const { name, value, onChangeModel } = this.props;
+            const { eventsListener } = this.context;
             this.updateModelWithValueOrOptions();
             if (eventsListener && typeof onChangeModel === 'function') {
                 this.onChangeModelMethod = ({ name, value }) => {

--- a/src/components/FieldConnect.jsx
+++ b/src/components/FieldConnect.jsx
@@ -13,12 +13,28 @@ export const FieldConnect = (Component) => {
             this.getEventsListener = this.getEventsListener.bind(this);
         }
 
+        updateModelWithValueOrOptions() {
+            const { name, value, options } = this.props;
+            const { setModel } = this.context;
+
+            if (!name || typeof setModel !== 'function') {
+                return;
+            }
+
+            if (name && value) {
+                setModel(name, value);
+            } else if (Array.isArray(options) && options.length) {
+                setModel(name, options[0].label ? options[0].value : options[0]);
+            }
+        }
+
         componentWillMount() {
             const { name, value, options, onChangeModel } = this.props;
             const { setModel, eventsListener } = this.context;
-            if (typeof setModel !== 'function') return;
-            if (name && value) setModel(name, value);
-            if (name && !value && options) setModel(name, options[0].label ? options[0].value : options[0]);
+            if (typeof setModel !== 'function') {
+                return;
+            }
+            this.updateModelWithValueOrOptions();
             if (eventsListener && typeof onChangeModel === 'function') {
                 this.onChangeModelMethod = ({ name, value }) => {
                     return onChangeModel({ name, value }, this);

--- a/tests/FieldConnect.test.jsx
+++ b/tests/FieldConnect.test.jsx
@@ -44,7 +44,6 @@ describe('FieldConnect', () => {
         const field = wrapper.find(TextField);
         expect(field.props().name).toBe(props.name);
         expect(field.props().label).toBe(props.label);
-        field.find('input').simulate('change', 'testValue');
     });
 
     it('without context from form should give props to SelectField', () => {
@@ -67,7 +66,6 @@ describe('FieldConnect', () => {
         expect(field.props().label).toBe(props.label);
         expect(field.props().options).toBe(props.options);
         expect(wrapper.component.getInstance().getPath()).toBe(props.name);
-        field.find('select').simulate('change', 'test3');
     });
 
     it('without context from form should give props to SelectField when options are objects', () => {
@@ -95,7 +93,6 @@ describe('FieldConnect', () => {
         expect(field.props().label).toBe(props.label);
         expect(field.props().options).toBe(props.options);
         expect(wrapper.component.getInstance().getPath()).toBe(props.name);
-        field.find('select').simulate('change', 'test3');
     });
 
     it('should give SubmitField submit method from form', () => {
@@ -120,5 +117,52 @@ describe('FieldConnect', () => {
         const field = wrapper.find(SubmitField);
         field.find('button').simulate('click');
         expect(field.props().value).toBe('Submit');
+    });
+
+    it('should update model when value is available', () => {
+        const context = {
+            setModel: jest.fn()
+        };
+        const props = {
+            name: 'name',
+            value: 'value'
+        };
+        const wrapper = mount(<TextFieldWithFormConnect {...props} />, {context});
+        expect(context.setModel).toHaveBeenCalledWith(props.name, props.value);
+    });
+
+    it('should not update model when value is not available', () => {
+        const context = {
+            setModel: jest.fn()
+        };
+        const props = {
+            name: 'name'
+        };
+        const wrapper = mount(<TextFieldWithFormConnect {...props} />, {context});
+        expect(context.setModel).not.toHaveBeenCalled();
+    });
+
+    it('should update model when options is available', () => {
+        const context = {
+            setModel: jest.fn()
+        };
+        const props = {
+            name: 'name',
+            options: [0, 1, 2]
+        };
+        const wrapper = mount(<TextFieldWithFormConnect {...props} />, {context});
+        expect(context.setModel).toHaveBeenCalledWith(props.name, props.options[0]);
+    });
+
+    it('should not update model when options is available but is empty', () => {
+        const context = {
+            setModel: jest.fn()
+        };
+        const props = {
+            name: 'name',
+            options: []
+        };
+        const wrapper = mount(<TextFieldWithFormConnect {...props} />, {context});
+        expect(context.setModel).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Fixed bug, where options[0].label was throwing error if options was an empty array.