### PR TITLE
Added support for boolean false values in FieldConnect

### DIFF
--- a/src/components/FieldConnect.jsx
+++ b/src/components/FieldConnect.jsx
@@ -70,8 +70,14 @@ export const FieldConnect = (Component) => {
         getValue() {
             const { name, value } = this.props;
             const { getModel } = this.context;
+
             if (typeof getModel !== 'function') return value;
-            return getModel(name) || value;
+
+            const valueFromModel = getModel(name);
+
+            return valueFromModel !== undefined
+                ? valueFromModel
+                : value;
         }
 
         getPropsFromSchema() {


### PR DESCRIPTION
Previous `getValue's` version wouldn't return a field's value if it was `false`. I've changed it to return `this.props.value` only if this field's value is not found in model (is `undefined`).