### PR TITLE
fix(AutocompleteField): Added missing regexp escape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8487,6 +8487,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -8539,15 +8548,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/components/AutocompleteField.js
+++ b/src/components/AutocompleteField.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import escapeRegExp from 'lodash/escapeRegExp';
 import FieldConnect from './FieldConnect';
 import ErrorField from './ErrorField';
 import { get, cloneArray } from '../helpers';
@@ -49,9 +50,10 @@ export class AutocompleteField extends Component {
         return true;
     }
 
-    suggestionsFilter(escapedValue, searchKey) {
+    suggestionsFilter(value, searchKey) {
+        const escapedValue = escapeRegExp(value);
         if (searchKey) {
-            return option => !!get(option, searchKey ,'').match(new RegExp(escapedValue, "i"))
+            return option => !!get(option, searchKey, '').match(new RegExp(escapedValue, 'i'));
         }
 
         return option => option.match(escapedValue);


### PR DESCRIPTION
Bez tej zmiany, konsola sypie błędami. Przy wprowadzaniu znaków `(`  `)` `[` `\` itd.